### PR TITLE
fix: correct frappe typo

### DIFF
--- a/themes/Catppuccin Frappe.theme
+++ b/themes/Catppuccin Frappe.theme
@@ -14,7 +14,7 @@ fish_color_gray 737994
 fish_color_selection --background=414559
 fish_color_search_match --background=414559
 fish_color_operator f4b8e4
-ish_color_escape eebebe
+fish_color_escape eebebe
 fish_color_autosuggestion 737994
 fish_color_cancel e78284
 fish_color_cwd e5c890


### PR DESCRIPTION
`ish_color_escape` -> `fish_color_escape`

Noticed this typo when playing with the theme this evening. 