### PR TITLE
docs: drop oh-my-fish installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,6 @@
 fisher install catppuccin/fish
 ```
 
-- [Oh My Fish](https://github.com/oh-my-fish/oh-my-fish)
-
-```sh
-omf install https://github.com/catppuccin/fish
-```
-
 2. Set your Fish theme to your chosen flavor:
 
 ```sh


### PR DESCRIPTION
these don't work as the repo is not structured in a way that omf
understands as being a theme.